### PR TITLE
Update run python command

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/init-thermostart/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-thermostart/run
@@ -19,7 +19,7 @@ fi
 
 cd /opt/services/web
 set +e
-python manage.py needs_alembic_version
+python3 manage.py needs_alembic_version
 if (test $? -eq 1)
 then
     python3 manage.py db stamp 26422f1f63d0


### PR DESCRIPTION
My logs show this error, and I suppose this is the fix ;)

```
/etc/s6-overlay/s6-rc.d/init-thermostart/run: line 22: python: command not found
```

I have not tested this! This seemed to me the easiest way to show both the error and the thing I think was causing it. I'm pretty sure the change itself is quite easy to see, but as this would mean the line will do actual work instead of generating an error, it could reveal more serious issues when it actually performs the python command :)